### PR TITLE
Adiciona link para a agenda

### DIFF
--- a/theme/templates/index.html
+++ b/theme/templates/index.html
@@ -11,6 +11,9 @@
       <a class="nav-link" href="#local">O evento</a>
     </div>
     <div class="nav-item">
+      <a class="nav-link" href="https://talks.python.org.br/pythonbrasil-2024/schedule/">Agenda</a>
+    </div>
+    <div class="nav-item">
       <a class="nav-link" href="#patrocinio">Patrocine</a>
     </div>
     <div class="nav-item">
@@ -351,7 +354,7 @@
         <a href="#" class="footer__link">Início</a>
       </li>
       <li>
-        <a href="#agenda" class="footer__link">Agenda</a>
+        <a href="https://talks.python.org.br/pythonbrasil-2024/schedule/" class="footer__link">Agenda</a>
       </li>
       <li>
         <a href="#local" class="footer__link">


### PR DESCRIPTION
Olá :)

Esse PR adiciona Link para agenda no menu superior e footer. 
https://talks.python.org.br/pythonbrasil-2024/schedule/

![Screenshot 2024-10-05 at 5 18 44 PM](https://github.com/user-attachments/assets/046fd6fe-c409-41b7-84b1-9de8fde7efd1)


![Screenshot 2024-10-05 at 5 19 12 PM](https://github.com/user-attachments/assets/1670931e-cdba-4866-b094-bf335ad25d4b)


